### PR TITLE
Add entry and exit reactions to pystate

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,1 @@
 from pystate import *
-
-from p


### PR DESCRIPTION
Entry and exit reactions are very useful if there are certain things
that have to be done every time we enter or leave a state (e.g.
cleanup). Instead of making sure that every handler performs the correct
tasks this will be handled by the function `transition_to`.

This is less error prone, more intuitive and saves key strokes.

Changes
    * The State class has 4 new methods:
        - add entry_reaction
        - remove entry_reaction
        - add exit_reaction
        - remove exit_reaction
    * In addition to changing the variable current_state the function
      `transition_to` does:
        - Call the exit reactions of the old state
        - Call the entry reactions of the new state